### PR TITLE
fix: blank page + ReferenceError after deploy (i18n array crash, t at module level)

### DIFF
--- a/frontend/src/i18n.jsx
+++ b/frontend/src/i18n.jsx
@@ -596,6 +596,7 @@ const STRINGS = {
 }
 
 function interpolate(template, params = {}) {
+  if (typeof template !== 'string') return template
   return template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => String(params[key] ?? ''))
 }
 


### PR DESCRIPTION
## Bugs fixed

### 1. Blank page — `interpolate()` crashes on array values (`i18n.jsx`)
`shoppingCategories` is stored as an array in i18n. The `interpolate()` helper called `.replace()` on it — arrays have no `.replace()` method, so it threw `TypeError`, which unmounted the entire React tree leaving a blank page.
**Fix:** one-line guard `if (typeof template !== 'string') return template`.

### 2. `ReferenceError: t is not defined` — `t()` called at module level (`SettingsPage.jsx`)
The `FAMILY_MEMBERS` field was added to the module-level `SETTING_GROUPS` constant using `t('familyMembers')` and `t('familyMembersDesc')` directly. `SETTING_GROUPS` is evaluated at module init time — `t` (a React hook value) is not in scope there.
**Fix:** use plain string literals in `SETTING_GROUPS`; register `FAMILY_MEMBERS` in `FIELD_LABEL_KEYS` / `FIELD_DESC_KEYS` so `localizeField()` translates them correctly at render time.

### 3. Variable shadowing — `t` reused as filter parameter (`TodoList.jsx`)
`const { t } = useI18n()` followed by `todos.filter((t) => …)` shadows the translation function within the arrow function scope, which can confuse minifiers.
**Fix:** rename filter parameter to `todo`.

## Test plan

- [ ] Navigate to `/` — app loads normally (no blank page, no console errors)
- [ ] Navigate to `/shopping` — page renders, category select is populated
- [ ] Navigate to `/settings` — FAMILY_MEMBERS field is visible and translates correctly in both EN and DE
- [ ] Confirm no `ReferenceError` or `TypeError` in browser console on any route