### PR TITLE
fix: ReferenceError — t() called at module level in SettingsPage

### DIFF
--- a/frontend/src/components/TodoList.jsx
+++ b/frontend/src/components/TodoList.jsx
@@ -15,8 +15,8 @@ export default function TodoList({ todos, onComplete }) {
     9: { label: t('priorityLow'), color: 'var(--success)' },
   }
 
-  const open = todos.filter((t) => !t.completed)
-  const done = todos.filter((t) => t.completed)
+  const open = todos.filter((todo) => !todo.completed)
+  const done = todos.filter((todo) => todo.completed)
 
   return (
     <div className="todo-list card">

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -52,6 +52,7 @@ const FIELD_LABEL_KEYS = {
   CALDAV_PASSWORD: 'settingsFieldAppSpecificPassword',
   CALDAV_CONFIGS: 'settingsCaldavConfigsLabel',
   VOICE_WEBHOOK_SECRET: 'settingsFieldWebhookSecret',
+  FAMILY_MEMBERS: 'familyMembers',
 }
 
 const FIELD_DESC_KEYS = {
@@ -72,6 +73,7 @@ const FIELD_DESC_KEYS = {
   CALDAV_PASSWORD: 'settingsFieldAppSpecificPasswordDesc',
   CALDAV_CONFIGS: 'settingsCaldavConfigsDesc',
   VOICE_WEBHOOK_SECRET: 'settingsFieldWebhookSecretDesc',
+  FAMILY_MEMBERS: 'familyMembersDesc',
 }
 
 function localizeField(t, field) {
@@ -121,7 +123,7 @@ const SETTING_GROUPS = [
         ],
       },
       { key: 'DAILY_SUMMARY_TIME', label: 'Daily briefing time', desc: 'HH:MM – when the morning summary is generated', type: 'time' },
-      { key: 'FAMILY_MEMBERS', label: t('familyMembers'), desc: t('familyMembersDesc'), type: 'text' },
+      { key: 'FAMILY_MEMBERS', label: 'Family Members', desc: 'Comma-separated names, e.g. Anna,Ben,Clara', type: 'text' },
     ],
   },
   {


### PR DESCRIPTION
## Problem

`FAMILY_MEMBERS` was added to the module-level `SETTING_GROUPS` constant using `t('familyMembers')` and `t('familyMembersDesc')` directly:

```js
// SETTING_GROUPS is a const at module scope — t is not available here!
{ key: 'FAMILY_MEMBERS', label: t('familyMembers'), desc: t('familyMembersDesc'), type: 'text' }
```

`SETTING_GROUPS` is evaluated at module initialisation time. `t` is a React hook value (from `useI18n()`) — it only exists inside a component render, so this produced `ReferenceError: t is not defined` in the minified bundle as soon as the Settings module was loaded.

## Fix

- Use plain string literals in `SETTING_GROUPS` (matches the pattern of every other field)
- Add `FAMILY_MEMBERS` to `FIELD_LABEL_KEYS` (`'familyMembers'`) and `FIELD_DESC_KEYS` (`'familyMembersDesc'`) so `localizeField()` translates the strings correctly at render time
- Rename the `TodoList` filter parameter from `(t)` to `(todo)` to avoid shadowing the `useI18n` `t` value in the same scope

## Test plan

- [ ] Open Settings page — FAMILY_MEMBERS field is visible
- [ ] Switch language to DE — field label shows "Familienmitglieder"
- [ ] No `ReferenceError` in browser console on any page

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRAgobcdLGpsxBYmiaxrZZ)_